### PR TITLE
Fix polygon flipping code

### DIFF
--- a/lua/CSG.lua
+++ b/lua/CSG.lua
@@ -19,11 +19,10 @@ function table.copy(t)
 end
 
 function table.reverse(t)
-    local s,t2 = #t,{}
-    for i,v in ipairs(t) do
-        t2[s-i] = v
-    end
-    return t2
+  for i=1, math.floor(#t / 2) do
+    t[i], t[#t - i + 1] = t[#t - i + 1], t[i]
+  end
+  return t
 end
 
 -- Constructive Solid Geometry (CSG) is a modeling technique that uses Boolean


### PR DESCRIPTION
I realize 8 years is a lot of time :smile: I noticed it had a serious bug which is fixed here, submitting PU for any future adopters. This library is still the best pure Lua library for manipulating meshes.

BTW this code is at the moment actively used in VR live-coding environment. I created a fork [here](https://github.com/jmiskovic/lovr-procmesh) with some further adaptations. Thanks for porting this to Lua.


The commit message:
```
Fix polygon flipping code

The table.reverse() was creating a new table which was not being saved
into Polygon object in flip() method. Also the reverse function had
off-by-one error where last element ended into 0 index.

Fixed by reversing the table in-place.
```